### PR TITLE
Treating command input as literal string

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,16 +24,14 @@ commands:
           command: f = fopen('myscript.m', 'w'); fwrite(f, 'assert(true)'); fclose(f);
       - matlab/run-command:
           command: myscript
-      - run:
-          command: echo 'export CMD=myscript' >> $BASH_ENV
-      - matlab/run-command:
-          command: $CMD
       - matlab/run-command:
           command: "eval(\"a = 1+2\"); assert(a == 3); eval('b = 3+4'); assert(b == 7);"
       - matlab/run-command:
           command: 'eval("a = 1+2"); assert(a == 3); eval(''b = 3+4''); assert(b == 7);'
       - matlab/run-command:
-          command: a = """hello world"""; b = '"hello world"'; assert(strcmp(a,b));
+          command: a = """hello world"""; b = '"hello world"'; assert(strcmp(a,b), a+b);
+      - matlab/run-command:
+          command: a = " !""#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~"; b = char([32:126]); assert(strcmp(a, b), a+b);
 
   test-run-tests:
     description: Test running MATLAB tests.

--- a/src/commands/run-command.yml
+++ b/src/commands/run-command.yml
@@ -13,15 +13,19 @@ steps:
   - run:
       name: Run MATLAB command
       command: |
+        define(){ read -r -d '' ${1} || true; }
+
         tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'run-command')
 
         # download run command shell scripts
         wget -qO "${tmpdir}/run-matlab-command.zip" https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v0/run-matlab-command.zip
         unzip -qod "${tmpdir}/bin" "${tmpdir}/run-matlab-command.zip"
 
-        # run MATLAB command
-        cmd=$(cat \<<_EOF
+        # create command to execute
+        define cmd \<<'_EOF'
         <<parameters.command>>
         _EOF
-        )
+        cmd=$(echo "$cmd" | sed 's/`/\\`/g')
+
+        # run MATLAB command
         "${tmpdir}/bin/run_matlab_command.sh" "$cmd"


### PR DESCRIPTION
This change treats the input to the `command` parameter of `run-command` as a literal string and properly escapes backticks.

By treating the input as a literal, we give up the ability to use bash variable substitution in a `command`. My feeling is `command` should never have supported bash variable substitution, as bash is an implementation detail and `command` is intended to be MATLAB. If bash variable substitution is required, you can drop down to calling `matlab -batch` from a bash script directly.

Closes #9 

