### PR TITLE
Treating command input as literal string

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands:
           command: a = """hello world"""; b = '"hello world"'; assert(strcmp(a,b), a+b);
       - matlab/run-command:
           command: |
-            a = " !""#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~"; b = char([32:126]); assert(strcmp(a, b), a+b);
+            a = " !""#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_\\\`abcdefghijklmnopqrstuvwxyz{|}~"; b = char([32:126]); assert(strcmp(a, b), a+b);
 
   test-run-tests:
     description: Test running MATLAB tests.

--- a/src/commands/run-command.yml
+++ b/src/commands/run-command.yml
@@ -25,7 +25,6 @@ steps:
         define cmd \<<'_EOF'
         <<parameters.command>>
         _EOF
-        cmd=$(printf '%s' "$cmd" | sed 's/`/\\`/g')
 
         # run MATLAB command
         "${tmpdir}/bin/run_matlab_command.sh" "$cmd"


### PR DESCRIPTION
This change treats the input to the `command` parameter of `run-command` as a literal string and properly escapes backticks.

By treating the input as a literal, we give up the ability to use bash variable substitution in a `command`. My feeling is `command` should never have supported bash variable substitution, as bash is an implementation detail and `command` is intended to be MATLAB. If bash variable substitution is required, you can drop down to calling `matlab -batch` from a bash script directly.