### PR TITLE
Improve orb metadata

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 description: >
-  Test MATLAB code and Simulink models, generate artifacts, and publish your results.
+  Run MATLAB and Simulink as part of your build pipeline.
 
 display:
   source_url: https://github.com/mathworks/matlab-circleci-orb

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 description: >
-  Run MATLAB and Simulink as part of your build pipeline.
+  Test MATLAB code and Simulink models, generate artifacts, and publish your results.
 
 display:
   source_url: https://github.com/mathworks/matlab-circleci-orb

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -5,4 +5,4 @@ description: >
 
 display:
   source_url: https://github.com/mathworks/matlab-circleci-orb
-  home_url: https://www.mathworks.com
+  home_url: https://www.mathworks.com/solutions/continuous-integration.html

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,6 +1,7 @@
 description: >
-  Install the latest MATLAB release on a Linux machine executor. You can use this command only for
-  public projects.
+  Install the latest MATLAB release on a Linux machine executor. Currently, this command is 
+  available only for public projects and does not include transformation products, such as MATLAB 
+  Coder and Embedded Coder.
 
 steps:
   - run:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,6 +1,6 @@
 description: >
-  Install the latest MATLAB release on a Linux machine executor. Currently, this command is 
-  available only for public projects and does not include transformation products, such as MATLAB 
+  Install the latest MATLAB release on a Linux machine executor. Currently, this command is
+  available only for public projects and does not include transformation products, such as MATLAB
   Coder and Embedded Coder.
 
 steps:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,7 +1,7 @@
 description: >
   Install the latest MATLAB release on a Linux machine executor. Currently, this command is
   available only for public projects and does not include transformation products, such as MATLAB
-  Coder and Embedded Coder.
+  Coder and MATLAB Compiler.
 
 steps:
   - run:


### PR DESCRIPTION
CircleCI recommended we expand our current orb description, shown below, to help with SEO:

https://github.com/mathworks/matlab-circleci-orb/blob/14a5dd9b1aa29f32cd8965a0199ffdeb8d64f6da/src/%40orb.yml#L4

@mw-hrastega and @asifouna can you help? This is the description that shows at the top of the [orb page](https://circleci.com/orbs/registry/orb/mathworks/matlab):

<img width="1165" alt="desc" src="https://user-images.githubusercontent.com/34887852/82485125-f4c5ac00-9aa8-11ea-920e-98b613ddbbb3.png">

Maybe some words to include: MBD, toolboxes, MEX, scripts, models?

I'm also wondering if perhaps we should be more forward looking with this line:

https://github.com/mathworks/matlab-circleci-orb/blob/2b939a70928e87d86e49512d4db543c3d079fdce/src/commands/install.yml#L2-L3

And say something like "Currently, this command is only available for public projects."?
