### PR TITLE
Writing command to script instead of passing directly to run_matlab_command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
           command: |
             a = " !""#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~"; b = char([32:126]); assert(strcmp(a, b), a+b);
       - matlab/run-command:
-          command: exp = getenv('CIRCLE_WORKING_DIRECTORY'); act = pwd; assert(strcmp(act, exp), strjoin({act exp}, '\n'));
+          command: \[~, exp] = system("echo " + getenv('CIRCLE_WORKING_DIRECTORY')); exp = strtrim(exp); act = pwd; assert(strcmp(act, exp), strjoin({act exp}, '\n'));
 
   integration-test-run-tests:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,9 @@ jobs:
           command: a = """hello world"""; b = '"hello world"'; assert(strcmp(a,b), a+b);
       - matlab/run-command:
           command: |
-            a = " !""#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_\\\`abcdefghijklmnopqrstuvwxyz{|}~"; b = char([32:126]); assert(strcmp(a, b), a+b);
+            a = " !""#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~"; b = char([32:126]); assert(strcmp(a, b), a+b);
+      - matlab/run-command:
+          command: exp = getenv('CIRCLE_WORKING_DIRECTORY'); act = pwd; assert(strcmp(act, exp), strjoin({act exp}, '\n'));
 
   integration-test-run-tests:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,8 @@ jobs:
           command: |
             a = " !""#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~"; b = char([32:126]); assert(strcmp(a, b), a+b);
       - matlab/run-command:
-          command: \[~, exp] = system("echo " + getenv('CIRCLE_WORKING_DIRECTORY')); exp = strtrim(exp); act = pwd; assert(strcmp(act, exp), strjoin({act exp}, '\n'));
+          command: |
+            [~, exp] = system("echo " + getenv('CIRCLE_WORKING_DIRECTORY')); exp = strtrim(exp); act = pwd; assert(strcmp(act, exp), strjoin({act exp}, '\n'));
 
   integration-test-run-tests:
     parameters:

--- a/src/commands/run-command.yml
+++ b/src/commands/run-command.yml
@@ -17,18 +17,20 @@ steps:
   - run:
       name: Run MATLAB command
       command: |
-        define(){ read -r -d '' ${1} || true; }
-
+        workdir=$(pwd)
         tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'run-command')
 
         # download run command shell scripts
         wget -qO "${tmpdir}/run-matlab-command.zip" https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v0/run-matlab-command.zip
         unzip -qod "${tmpdir}/bin" "${tmpdir}/run-matlab-command.zip"
 
-        # create command to execute
-        define cmd \<<'_EOF'
+        # create script to execute
+        script=command${RANDOM}
+        scriptpath=${tmpdir}/${script}.m
+        echo "cd('${workdir}');" > "$scriptpath"
+        cat <<'_EOF' >> "$scriptpath"
         <<parameters.command>>
         _EOF
 
         # run MATLAB command
-        "${tmpdir}/bin/run_matlab_command.sh" "$cmd"
+        (cd "$tmpdir" && bin/run_matlab_command.sh $script)

--- a/src/commands/run-command.yml
+++ b/src/commands/run-command.yml
@@ -27,10 +27,10 @@ steps:
         # create script to execute
         script=command_${RANDOM}
         scriptpath=${tmpdir}/${script}.m
-        echo "cd('${workdir}');" > "$scriptpath"
+        echo "cd('${workdir//\'/\'\'}');" > "$scriptpath"
         cat \<<'_EOF' >> "$scriptpath"
         <<parameters.command>>
         _EOF
 
         # run MATLAB command
-        (cd "$tmpdir" && bin/run_matlab_command.sh $script)
+        (cd "$tmpdir" && bin/run_matlab_command.sh "$script")

--- a/src/commands/run-command.yml
+++ b/src/commands/run-command.yml
@@ -25,10 +25,10 @@ steps:
         unzip -qod "${tmpdir}/bin" "${tmpdir}/run-matlab-command.zip"
 
         # create script to execute
-        script=command${RANDOM}
+        script=command_${RANDOM}
         scriptpath=${tmpdir}/${script}.m
         echo "cd('${workdir}');" > "$scriptpath"
-        cat <<'_EOF' >> "$scriptpath"
+        cat \<<'_EOF' >> "$scriptpath"
         <<parameters.command>>
         _EOF
 


### PR DESCRIPTION
This change brings the Circle orb in line with the other integrations where we write the command given to `run-command` to a temp script instead of trying to pass it directly to `run_matlab_command`.

Bash does not have a builtin UUID generator and I do not want to rely on the system having a dependency like `uuidgen`, so I am appending the script name with a random number instead of a UUID. The script goes into a fresh tempdir every run, so there is no chance of name collision, the random number just helps further communicate the script is temporary.

Circle already displays the command the user put in, so I did not print it again.

Resolves #9