### PR TITLE
Fix for execution of startup.m in project root folder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,10 @@ jobs:
       - matlab/run-command:
           command: |
             [~, exp] = system("echo " + getenv('CIRCLE_WORKING_DIRECTORY')); exp = strtrim(exp); act = pwd; assert(strcmp(act, exp), strjoin({act exp}, '\n'));
+      - run:
+          command: echo 'myvar = 123' > startup.m
+      - matlab/run-command:
+          command: assert(myvar==123, 'myvar was not set as expected by startup.m')
 
   integration-test-run-tests:
     parameters:
@@ -75,10 +79,14 @@ jobs:
       - matlab/install
       - run:
           command: |
+            echo 'myvar = 123' > startup.m
             mkdir src
             echo 'function c=add(a,b);c=a+b;' > src/add.m
             mkdir tests
-            printf "%%%% FirstTest\nassert(add(1,2)==3)" > tests/mytest.m
+            echo "%% StartupTest" > tests/mytest.m
+            echo "evalin('base','assert(myvar==123)')" >> tests/mytest.m
+            echo "%% FirstTest" >> tests/mytest.m
+            echo "assert(add(1,2)==3)" >> tests/mytest.m
       - matlab/run-tests:
           source-folder: src
       - matlab/run-tests:

--- a/src/commands/run-command.yml
+++ b/src/commands/run-command.yml
@@ -33,4 +33,4 @@ steps:
         _EOF
 
         # run MATLAB command
-        (cd "$tmpdir" && bin/run_matlab_command.sh "$script")
+        "${tmpdir}/bin/run_matlab_command.sh" "cd('${tmpdir//\'/\'\'}'); $script"


### PR DESCRIPTION
This change ensures `run-command` opens MATLAB in the current working folder, rather than the temp folder, so that a `startup.m` file the user may have in their working folder is executed.