### PR TITLE
Updated run-tests to use Script.run

### DIFF
--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -41,11 +41,11 @@ steps:
         # generate and run MATLAB test script
         "${tmpdir}/bin/run_matlab_command.sh" "\
           addpath('${tmpdir}/scriptgen');\
-          testScript = genscript('Test','WorkingFolder','..',\
+          testScript = genscript('Test',\
             'JUnitTestResults','<<parameters.test-results-junit>>',\
             'CoberturaCodeCoverage','<<parameters.code-coverage-cobertura>>',\
             'SourceFolder','<<parameters.source-folder>>');\
-          disp('Running:');\
+          disp('Running MATLAB script with content:');\
           disp(strtrim(testScript.writeToText()));\
           fprintf('__________\n\n');\
           run(testScript);"

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -45,11 +45,7 @@ steps:
             'JUnitTestResults','<<parameters.test-results-junit>>',\
             'CoberturaCodeCoverage','<<parameters.code-coverage-cobertura>>',\
             'SourceFolder','<<parameters.source-folder>>');\
-          scriptFolder = '.matlab';\
-          scriptPath = fullfile(scriptFolder, 'runAllTests.m');\
-          testScript.writeToFile(scriptPath);\
-          disp(['Running ''' scriptPath ''':']);\
-          type(scriptPath);\
+          disp('Running:');\
+          disp(strtrim(testScript.writeToText()));\
           fprintf('__________\n\n');\
-          cd(scriptFolder);\
-          runAllTests;"
+          run(testScript);"


### PR DESCRIPTION
This change simplifies the run-tests command implementation by using the `Script.run` method.