### PR TITLE
[semver:minor] add release parameter to install command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,7 @@ parameters:
 integration-tests: &integration-tests
   [
     integration-test-install,
+    integration-test-install-release,
     integration-test-run-command,
     integration-test-run-tests
   ]
@@ -41,6 +42,20 @@ jobs:
             set -e
             matlab -batch version
             mex -h
+
+  integration-test-install-release:
+    parameters:
+      executor:
+        type: executor
+    executor: <<parameters.executor>>
+    steps:
+      - matlab/install:
+          release: R2020a
+      - run:
+          name: Verify the matlab and mex scripts are available
+          command: |
+            set -e
+            matlab -batch "assert(strcmp(version('-release'),'2020a'))"
 
   integration-test-run-command:
     parameters:
@@ -146,6 +161,11 @@ workflows:
       # jobs and commands to ensure they behave as expected. or, run other
       # integration tests of your choosing
       - integration-test-install:
+          matrix:
+            parameters:
+              executor: [linux-machine]
+
+      - integration-test-install-release:
           matrix:
             parameters:
               executor: [linux-machine]

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,7 +1,15 @@
 description: >
-  Install the latest MATLAB release on a Linux machine executor. Currently, this command is
-  available only for public projects and does not include transformation products, such as MATLAB
-  Coder and MATLAB Compiler.
+  Install MATLAB on a Linux machine executor. Currently, this command is available only for public
+  projects and does not include transformation products, such as MATLAB Coder and MATLAB Compiler.
+
+parameters:
+  release:
+    description: >
+      MATLAB release to install. The value specified should follow the MATLAB release naming
+      convention (e.g. R2020a). The latest release will be installed by default. Releases R2020a and
+      above are available shortly after their general release on MathWorks.com.
+    type: string
+    default: 'latest'
 
 steps:
   - run:
@@ -14,7 +22,7 @@ steps:
         fi
 
         # install core system dependencies
-        wget -qO- --retry-connrefused https://ssd.mathworks.com/supportfiles/ci/matlab-deps/v0/install.sh | sudo -E bash
+        wget -qO- --retry-connrefused https://ssd.mathworks.com/supportfiles/ci/matlab-deps/v0/install.sh | sudo -E bash -s -- <<parameters.release>>
 
         # install ephemeral version of MATLAB
-        wget -qO- --retry-connrefused https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/install.sh | sudo -E bash
+        wget -qO- --retry-connrefused https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/install.sh | sudo -E bash -s -- --release <<parameters.release>>

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -5,9 +5,8 @@ description: >
 parameters:
   release:
     description: >
-      MATLAB release to install. The value specified should follow the MATLAB release naming
-      convention (e.g. R2020a). The latest release will be installed by default. Releases R2020a and
-      above are available shortly after their general release on MathWorks.com.
+      MATLAB release to install. You can specify R2020a or a later release. By default, the command
+      installs the latest release of MATLAB.
     type: string
     default: 'latest'
 


### PR DESCRIPTION
This change adds a `release` parameter to the `install` command, where the user can specify the release of MATLAB to install:

```yaml
steps:
- matlab/install:
    release: R2020a
```