### PR TITLE
Move to mathworks-ci.com for all assets

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -21,7 +21,7 @@ steps:
         fi
 
         # install core system dependencies
-        wget -qO- --retry-connrefused https://ssd.mathworks.com/supportfiles/ci/matlab-deps/v0/install.sh | sudo -E bash -s -- <<parameters.release>>
+        wget -qO- --retry-connrefused https://static.mathworks-ci.com/matlab-deps/v0/install.sh | sudo -E bash -s -- <<parameters.release>>
 
         # install ephemeral version of MATLAB
-        wget -qO- --retry-connrefused https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh | sudo -E bash -s -- --release <<parameters.release>>
+        wget -qO- --retry-connrefused https://static.mathworks-ci.com/ephemeral-matlab/v0/ci-install.sh | sudo -E bash -s -- --release <<parameters.release>>

--- a/src/commands/run-command.yml
+++ b/src/commands/run-command.yml
@@ -21,7 +21,7 @@ steps:
         tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'run-command')
 
         # download run command shell scripts
-        wget -qO "${tmpdir}/run-matlab-command.zip" https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v0/run-matlab-command.zip
+        wget -qO "${tmpdir}/run-matlab-command.zip" https://static.mathworks-ci.com/run-matlab-command/v0/run-matlab-command.zip
         unzip -qod "${tmpdir}/bin" "${tmpdir}/run-matlab-command.zip"
 
         # create script to execute

--- a/src/commands/run-tests.yml
+++ b/src/commands/run-tests.yml
@@ -31,11 +31,11 @@ steps:
         tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'run-tests')
 
         # download run command shell scripts
-        wget -qO "${tmpdir}/bin.zip" https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v0/run-matlab-command.zip
+        wget -qO "${tmpdir}/bin.zip" https://static.mathworks-ci.com/run-matlab-command/v0/run-matlab-command.zip
         unzip -qod "${tmpdir}/bin" "${tmpdir}/bin.zip"
 
         # download script generator
-        wget -qO "${tmpdir}/scriptgen.zip" https://ssd.mathworks.com/supportfiles/ci/matlab-script-generator/v0/matlab-script-generator.zip
+        wget -qO "${tmpdir}/scriptgen.zip" https://static.mathworks-ci.com/matlab-script-generator/v0/matlab-script-generator.zip
         unzip -qod "${tmpdir}/scriptgen" "${tmpdir}/scriptgen.zip"
 
         # generate and run MATLAB test script


### PR DESCRIPTION
This change switches all references of `ssd.mathworks.com` to `static.mathworks-ci.com`.