### PR TITLE
Update to use new run-matlab-command

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -23,22 +23,22 @@ fi
 
 # install ephemeral version of MATLAB
 if [ -n "${MATHWORKS_ACCOUNT}" ] &&  [ -n "${MATHWORKS_TOKEN}" ]; then
-    ACTIVATION_FLAG="--skip-activation"
+    activationFlag="--skip-activation"
 fi
 
-downloadAndRun https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh --release ${PARAM_RELEASE} $ACTIVATION_FLAG
+downloadAndRun https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh --release ${PARAM_RELEASE} $activationFlag
 
 # install matlab-batch
 if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
-    BATCH_INSTALL_DIR='C:\Program Files\matlab-batch'
+    batchInstallDir='C:\Program Files\matlab-batch'
 else
-    BATCH_INSTALL_DIR='/opt/matlab-batch'
+    batchInstallDir='/opt/matlab-batch'
 fi
 
-downloadAndRun https://ssd.mathworks.com/supportfiles/ci/matlab-batch/v0/install.sh "$BATCH_INSTALL_DIR"
+downloadAndRun https://ssd.mathworks.com/supportfiles/ci/matlab-batch/v0/install.sh "$batchInstallDir"
 
 # add MATLAB and matlab-batch to path
 tmpdir=$(dirname "$(mktemp -u)")
 rootdir=$(cat "$tmpdir/ephemeral_matlab_root")
 
-echo 'export PATH="'$rootdir'/bin:'$BATCH_INSTALL_DIR':$PATH"' >> $BASH_ENV
+echo 'export PATH="'$rootdir'/bin:'$batchInstallDir':$PATH"' >> $BASH_ENV

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -22,7 +22,7 @@ if [[ $os = Linux ]]; then
 fi
 
 # install ephemeral version of MATLAB
-if ! [ -z "${MATHWORKS_ACCOUNT}" ] &&  ! [ -z "${MATHWORKS_TOKEN}" ]; then
+if [ -n "${MATHWORKS_ACCOUNT}" ] &&  [ -n "${MATHWORKS_TOKEN}" ]; then
     ACTIVATION_FLAG="--skip-activation"
 fi
 ACTIVATION_FLAG="--skip-activation"

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -18,7 +18,7 @@ fi
 
 # install core system dependencies
 if [[ $os = Linux ]]; then
-    downloadAndRun https://ssd.mathworks.com/supportfiles/ci/matlab-deps/v0/install.sh ${PARAM_RELEASE}
+    downloadAndRun https://ssd.mathworks.com/supportfiles/ci/matlab-deps/v0/install.sh "${PARAM_RELEASE}"
 fi
 
 # install ephemeral version of MATLAB
@@ -26,7 +26,7 @@ if [ -n "${MATHWORKS_ACCOUNT}" ] &&  [ -n "${MATHWORKS_TOKEN}" ]; then
     activationFlag="--skip-activation"
 fi
 
-downloadAndRun https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh --release ${PARAM_RELEASE} $activationFlag
+downloadAndRun https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh --release "${PARAM_RELEASE}" $activationFlag
 
 tmpdir=$(dirname "$(mktemp -u)")
 rootdir=$(cat "$tmpdir/ephemeral_matlab_root")

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -33,7 +33,7 @@ rootdir=$(cat "$tmpdir/ephemeral_matlab_root")
 
 # install matlab-batch
 if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
-    batchInstallDir='C:\Program Files\matlab-batch'
+    batchInstallDir='/c/Program Files/matlab-batch'
     rootdir=$(cygpath "$rootdir")
 else
     batchInstallDir='/opt/matlab-batch'

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -28,9 +28,13 @@ fi
 
 downloadAndRun https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh --release ${PARAM_RELEASE} $activationFlag
 
+tmpdir=$(dirname "$(mktemp -u)")
+rootdir=$(cat "$tmpdir/ephemeral_matlab_root")
+
 # install matlab-batch
 if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
     batchInstallDir='C:\Program Files\matlab-batch'
+    rootdir=$(cygpath "$rootdir")
 else
     batchInstallDir='/opt/matlab-batch'
 fi
@@ -38,7 +42,4 @@ fi
 downloadAndRun https://ssd.mathworks.com/supportfiles/ci/matlab-batch/v0/install.sh "$batchInstallDir"
 
 # add MATLAB and matlab-batch to path
-tmpdir=$(dirname "$(mktemp -u)")
-rootdir=$(cat "$tmpdir/ephemeral_matlab_root")
-
 echo 'export PATH="'$rootdir'/bin:'$batchInstallDir':$PATH"' >> $BASH_ENV

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -22,12 +22,23 @@ if [[ $os = Linux ]]; then
 fi
 
 # install ephemeral version of MATLAB
-downloadAndRun https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh --release ${PARAM_RELEASE}
+if ! [ -z "${MATHWORKS_ACCOUNT}" ] &&  ! [ -z "${MATHWORKS_TOKEN}" ]; then
+    ACTIVATION_FLAG="--skip-activation"
+fi
+ACTIVATION_FLAG="--skip-activation"
+downloadAndRun https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh --release ${PARAM_RELEASE} $ACTIVATION_FLAG
 
-# add MATLAB to path
+# install matlab-batch
+if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
+    BATCH_INSTALL_DIR='C:\Program Files\matlab-batch'
+else
+    BATCH_INSTALL_DIR='/opt/matlab-batch'
+fi
+
+downloadAndRun https://ssd.mathworks.com/supportfiles/ci/matlab-batch/v0/install.sh "$BATCH_INSTALL_DIR"
+
+# add MATLAB and matlab-batch to path
 tmpdir=$(dirname "$(mktemp -u)")
 rootdir=$(cat "$tmpdir/ephemeral_matlab_root")
-if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
-    rootdir=$(cygpath "$rootdir")
-fi
-echo 'export PATH="'$rootdir'/bin:$PATH"' >> $BASH_ENV
+
+echo 'export PATH="'$rootdir'/bin:'$BATCH_INSTALL_DIR':$PATH"' >> $BASH_ENV

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -25,7 +25,7 @@ fi
 if [ -n "${MATHWORKS_ACCOUNT}" ] &&  [ -n "${MATHWORKS_TOKEN}" ]; then
     ACTIVATION_FLAG="--skip-activation"
 fi
-ACTIVATION_FLAG="--skip-activation"
+
 downloadAndRun https://ssd.mathworks.com/supportfiles/ci/ephemeral-matlab/v0/ci-install.sh --release ${PARAM_RELEASE} $ACTIVATION_FLAG
 
 # install matlab-batch

--- a/src/scripts/run-command.sh
+++ b/src/scripts/run-command.sh
@@ -1,16 +1,27 @@
+downloadAndRun() {
+    url=$1
+    shift
+    if [[ -x $(command -v sudo) ]]; then
+    curl -sfL $url | sudo -E bash -s -- "$@"
+    else
+    curl -sfL $url | bash -s -- "$@"
+    fi
+}
+
 tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'run-command')
 
-# download run command shell scripts
-curl -sfLo "${tmpdir}/run-matlab-command.zip" https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v0/run-matlab-command.zip
-unzip -qod "${tmpdir}/bin" "${tmpdir}/run-matlab-command.zip"
+# install run-matlab-command
+downloadAndRun https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v1/install.sh "${tmpdir}/bin"
 
 # form OS appropriate paths for MATLAB
 os=$(uname)
 workdir=$(pwd)
 scriptdir=$tmpdir
+binext=""
 if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
     workdir=$(cygpath -w "$workdir")
     scriptdir=$(cygpath -w "$scriptdir")
+    binext=".exe"
 fi
 
 # create script to execute
@@ -22,4 +33,4 @@ ${PARAM_COMMAND}
 EOF
 
 # run MATLAB command
-"${tmpdir}/bin/run_matlab_command.sh" "cd('${scriptdir//\'/\'\'}'); $script"
+"${tmpdir}/bin/run-matlab-command$binext" "cd('${scriptdir//\'/\'\'}');$script"

--- a/src/scripts/run-tests.sh
+++ b/src/scripts/run-tests.sh
@@ -20,11 +20,9 @@ unzip -qod "${tmpdir}/scriptgen" "${tmpdir}/scriptgen.zip"
 # form OS appropriate paths for MATLAB
 os=$(uname)
 gendir=$tmpdir
-workdir=$(pwd)
 binext=""
 if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
     gendir=$(cygpath -w "$gendir")
-    workdir=$(cygpath -w "$workdir")
     binext=".exe"
 fi
 

--- a/src/scripts/run-tests.sh
+++ b/src/scripts/run-tests.sh
@@ -33,7 +33,7 @@ script=command_${RANDOM}
 scriptpath=${tmpdir}/${script}.m
 echo "cd('${workdir//\'/\'\'}');" > "$scriptpath"
 cat << EOF >> "$scriptpath"
-"addpath('${gendir}/scriptgen');\
+addpath('${gendir}/scriptgen');\
 testScript = genscript('Test',\
 'JUnitTestResults','${PARAM_TEST_RESULTS_JUNIT}',\
 'CoberturaCodeCoverage','${PARAM_CODE_COVERAGE_COBERTURA}',\
@@ -49,7 +49,7 @@ testScript = genscript('Test',\
 disp('Running MATLAB script with contents:');\
 disp(testScript.Contents);\
 fprintf('__________\n\n');\
-run(testScript);"
+run(testScript);
 EOF
 
 "${tmpdir}/bin/run-matlab-command$binext" "cd('${gendir//\'/\'\'}');$script"

--- a/src/scripts/run-tests.sh
+++ b/src/scripts/run-tests.sh
@@ -1,8 +1,17 @@
+downloadAndRun() {
+    url=$1
+    shift
+    if [[ -x $(command -v sudo) ]]; then
+    curl -sfL $url | sudo -E bash -s -- "$@"
+    else
+    curl -sfL $url | bash -s -- "$@"
+    fi
+}
+
 tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t 'run-tests')
 
-# download run command shell scripts
-curl -sfLo "${tmpdir}/bin.zip" https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v0/run-matlab-command.zip
-unzip -qod "${tmpdir}/bin" "${tmpdir}/bin.zip"
+# install run-matlab-command
+downloadAndRun https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v1/install.sh "${tmpdir}/bin"
 
 # download script generator
 curl -sfLo "${tmpdir}/scriptgen.zip" https://ssd.mathworks.com/supportfiles/ci/matlab-script-generator/v0/matlab-script-generator.zip
@@ -11,26 +20,34 @@ unzip -qod "${tmpdir}/scriptgen" "${tmpdir}/scriptgen.zip"
 # form OS appropriate paths for MATLAB
 os=$(uname)
 gendir=$tmpdir
+binext=""
 if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
     gendir=$(cygpath -w "$gendir")
+    binext=".exe"
 fi
 
 # generate and run MATLAB test script
-"${tmpdir}/bin/run_matlab_command.sh" "\
-    addpath('${gendir}/scriptgen');\
-    testScript = genscript('Test',\
-    'JUnitTestResults','${PARAM_TEST_RESULTS_JUNIT}',\
-    'CoberturaCodeCoverage','${PARAM_CODE_COVERAGE_COBERTURA}',\
-    'HTMLCodeCoverage','${PARAM_CODE_COVERAGE_HTML}',\
-    'SourceFolder','${PARAM_SOURCE_FOLDER}',\
-    'SelectByFolder','${PARAM_SELECT_BY_FOLDER}',\
-    'SelectByTag','$PARAM_SELECT_BY_TAG',\
-    'CoberturaModelCoverage','${PARAM_MODEL_COVERAGE_COBERTURA}',\
-    'HTMLModelCoverage','${PARAM_MODEL_COVERAGE_HTML}',\
-    'SimulinkTestResults','${PARAM_TEST_RESULTS_SIMULINK_TEST}',\
-    'HTMLTestReport','${PARAM_TEST_RESULTS_HTML}',\
-    'PDFTestReport','${PARAM_TEST_RESULTS_PDF}');\
-    disp('Running MATLAB script with contents:');\
-    disp(testScript.Contents);\
-    fprintf('__________\n\n');\
-    run(testScript);"
+script=command_${RANDOM}
+scriptpath=${tmpdir}/${script}.m
+echo "cd('${workdir//\'/\'\'}');" > "$scriptpath"
+cat << EOF >> "$scriptpath"
+"addpath('${gendir}/scriptgen');\
+testScript = genscript('Test',\
+'JUnitTestResults','${PARAM_TEST_RESULTS_JUNIT}',\
+'CoberturaCodeCoverage','${PARAM_CODE_COVERAGE_COBERTURA}',\
+'HTMLCodeCoverage','${PARAM_CODE_COVERAGE_HTML}',\
+'SourceFolder','${PARAM_SOURCE_FOLDER}',\
+'SelectByFolder','${PARAM_SELECT_BY_FOLDER}',\
+'SelectByTag','$PARAM_SELECT_BY_TAG',\
+'CoberturaModelCoverage','${PARAM_MODEL_COVERAGE_COBERTURA}',\
+'HTMLModelCoverage','${PARAM_MODEL_COVERAGE_HTML}',\
+'SimulinkTestResults','${PARAM_TEST_RESULTS_SIMULINK_TEST}',\
+'HTMLTestReport','${PARAM_TEST_RESULTS_HTML}',\
+'PDFTestReport','${PARAM_TEST_RESULTS_PDF}');\
+disp('Running MATLAB script with contents:');\
+disp(testScript.Contents);\
+fprintf('__________\n\n');\
+run(testScript);"
+EOF
+
+"${tmpdir}/bin/run-matlab-command$binext" "cd('${gendir//\'/\'\'}');$script"

--- a/src/scripts/run-tests.sh
+++ b/src/scripts/run-tests.sh
@@ -28,28 +28,21 @@ if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
     binext=".exe"
 fi
 
-# generate and run MATLAB test script
-script=command_${RANDOM}
-scriptpath=${tmpdir}/${script}.m
-echo "cd('${workdir//\'/\'\'}');" > "$scriptpath"
-cat << EOF >> "$scriptpath"
-addpath('${gendir}/scriptgen');\
-testScript = genscript('Test',\
-'JUnitTestResults','${PARAM_TEST_RESULTS_JUNIT}',\
-'CoberturaCodeCoverage','${PARAM_CODE_COVERAGE_COBERTURA}',\
-'HTMLCodeCoverage','${PARAM_CODE_COVERAGE_HTML}',\
-'SourceFolder','${PARAM_SOURCE_FOLDER}',\
-'SelectByFolder','${PARAM_SELECT_BY_FOLDER}',\
-'SelectByTag','$PARAM_SELECT_BY_TAG',\
-'CoberturaModelCoverage','${PARAM_MODEL_COVERAGE_COBERTURA}',\
-'HTMLModelCoverage','${PARAM_MODEL_COVERAGE_HTML}',\
-'SimulinkTestResults','${PARAM_TEST_RESULTS_SIMULINK_TEST}',\
-'HTMLTestReport','${PARAM_TEST_RESULTS_HTML}',\
-'PDFTestReport','${PARAM_TEST_RESULTS_PDF}');\
-disp('Running MATLAB script with contents:');\
-disp(testScript.Contents);\
-fprintf('__________\n\n');\
-run(testScript);
-EOF
-
-"${tmpdir}/bin/run-matlab-command$binext" "cd('${gendir//\'/\'\'}');$script"
+"${tmpdir}/bin/run-matlab-command$binext" "\
+    addpath('${gendir}/scriptgen');\
+    testScript = genscript('Test',\
+    'JUnitTestResults','${PARAM_TEST_RESULTS_JUNIT}',\
+    'CoberturaCodeCoverage','${PARAM_CODE_COVERAGE_COBERTURA}',\
+    'HTMLCodeCoverage','${PARAM_CODE_COVERAGE_HTML}',\
+    'SourceFolder','${PARAM_SOURCE_FOLDER}',\
+    'SelectByFolder','${PARAM_SELECT_BY_FOLDER}',\
+    'SelectByTag','$PARAM_SELECT_BY_TAG',\
+    'CoberturaModelCoverage','${PARAM_MODEL_COVERAGE_COBERTURA}',\
+    'HTMLModelCoverage','${PARAM_MODEL_COVERAGE_HTML}',\
+    'SimulinkTestResults','${PARAM_TEST_RESULTS_SIMULINK_TEST}',\
+    'HTMLTestReport','${PARAM_TEST_RESULTS_HTML}',\
+    'PDFTestReport','${PARAM_TEST_RESULTS_PDF}');\
+    disp('Running MATLAB script with contents:');\
+    disp(testScript.Contents);\
+    fprintf('__________\n\n');\
+    run(testScript);"

--- a/src/scripts/run-tests.sh
+++ b/src/scripts/run-tests.sh
@@ -24,7 +24,7 @@ workdir=$(pwd)
 binext=""
 if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
     gendir=$(cygpath -w "$gendir")
-    workdir=$(pwd)
+    workdir=$(cygpath -w "$workdir")
     binext=".exe"
 fi
 

--- a/src/scripts/run-tests.sh
+++ b/src/scripts/run-tests.sh
@@ -20,9 +20,11 @@ unzip -qod "${tmpdir}/scriptgen" "${tmpdir}/scriptgen.zip"
 # form OS appropriate paths for MATLAB
 os=$(uname)
 gendir=$tmpdir
+workdir=$(pwd)
 binext=""
 if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
     gendir=$(cygpath -w "$gendir")
+    workdir=$(pwd)
     binext=".exe"
 fi
 


### PR DESCRIPTION
- Use new binary for run-command and run-tests
- skip ematlab activation if MATHWORKS_TOKEN and MATHWORKS_ACCOUNT are present in environment