### PR TITLE
Mpm publish beta

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ filters: &filters
 
 jobs:
   publish-v2-beta:
-    machine:
-      image: ubuntu-2004:202010-01
+    docker:
+      - image: circleci/circleci-cli:latest
     steps:
     - run:
         name: publish v2-beta as dev orb
@@ -45,12 +45,12 @@ workflows:
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           filters: *filters          
-      - publish-v2-beta:
-        when:
-          condition:
-            and:
-              not: publish-v2-beta
-              equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
+      - publish-v2-beta
+        #when:
+        #  condition:
+        #    and:
+        #      equal: [ true, << pipeline.parameters.publish-v2-beta >> ]
+        #      equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
           pipeline-number: << pipeline.number >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,14 +21,14 @@ jobs:
       - when:
           condition: << pipeline.parameters.publish-v2-beta >>
           steps:
+            - attach_workspace:
+                at: ./dist/
             - run:
                 name: publish v2-beta as dev orb
                 command: |
                   circleci --help
                   circleci version
                   circleci orb publish --host "https://circleci.com" --skip-update-check "./dist/orb.yml" "mathworks/matlab@dev:v2-beta" --token "$CIRCLE_TOKEN"
-            - attach_workspace:
-                at: ./dist/
       - unless:
           condition: << pipeline.parameters.publish-v2-beta >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,8 @@ jobs:
     - run:
         name: publish v2-beta as dev orb
         command: |
+          circleci --help
+          circleci version
           circleci orb publish --host "https://circleci.com" --skip-update-check "./dist/orb.yml" "mathworks/matlab@dev:v2-beta" --token "$CIRCLE_TOKEN"
 
 workflows:
@@ -46,7 +48,9 @@ workflows:
       - publish-v2-beta:
         when:
           condition:
-            equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
+            and:
+              not: publish-v2-beta
+              equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
           pipeline-number: << pipeline.number >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
   shellcheck: circleci/shellcheck@3.1
 
 parameters:
-  publish-v2-beta:
+  publish-v1-beta:
     type: boolean
     default: false
 
@@ -14,25 +14,25 @@ filters: &filters
     only: /.*/
 
 jobs:
-  publish-v2-beta:
+  publish-v1-beta:
     docker:
       - image: circleci/circleci-cli:latest
     steps:
       - when:
-          condition: << pipeline.parameters.publish-v2-beta >>
+          condition: << pipeline.parameters.publish-v1-beta >>
           steps:
             - attach_workspace:
                 at: ./dist/
             - run:
-                name: publish v2-beta as dev orb
+                name: publish v1-beta as dev orb
                 command: |
-                  circleci orb publish --host "https://circleci.com" --skip-update-check "./dist/orb.yml" "mathworks/matlab@dev:v2-beta" --token "$CIRCLE_TOKEN"
+                  circleci orb publish --host "https://circleci.com" --skip-update-check "./dist/orb.yml" "mathworks/matlab@dev:v1-beta" --token "$CIRCLE_TOKEN"
       - unless:
-          condition: << pipeline.parameters.publish-v2-beta >>
+          condition: << pipeline.parameters.publish-v1-beta >>
           steps:
           - run:
               command: |
-                echo "skipping publish v2-beta"
+                echo "skipping publish v1-beta"
 
 workflows:
   lint-pack:
@@ -54,7 +54,7 @@ workflows:
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           filters: *filters
-      - publish-v2-beta:
+      - publish-v1-beta:
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
       # Triggers the next workflow in the Orb Development Kit.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,12 +45,13 @@ workflows:
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           filters: *filters          
-      - publish-v2-beta
-        #when:
-        #  condition:
-        #    and:
-        #      equal: [ true, << pipeline.parameters.publish-v2-beta >> ]
-        #      equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
+      - publish-v2-beta:
+          requires: [orb-tools/publish]
+      #     when:
+      #       condition:
+      #         and:
+      #           equal: [ true, << pipeline.parameters.publish-v2-beta >> ]
+      #           equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
           pipeline-number: << pipeline.number >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,11 +50,11 @@ workflows:
       - publish-v2-beta:
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
-      #     when:
-      #       condition:
-      #         and:
-      #           equal: [ true, << pipeline.parameters.publish-v2-beta >> ]
-      #           equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
+          when:
+            condition:
+              and:
+                - equal: [ true, << pipeline.parameters.publish-v2-beta >> ]
+                - equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
           pipeline-number: << pipeline.number >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,9 +55,7 @@ workflows:
           filters: *filters
     when:
       condition:
-        and:
-          - equal: [ true, << pipeline.parameters.publish-v2-beta >> ]
-          - equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
+        equal: [ true, << pipeline.parameters.publish-v2-beta >> ]
       jobs:
         - publish-v2-beta:
             requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,19 +18,23 @@ jobs:
     docker:
       - image: circleci/circleci-cli:latest
     steps:
-    - attach_workspace:
-        at: ./dist/
-    - run:
-        name: publish v2-beta as dev orb
-        command: |
-          circleci --help
-          circleci version
-          circleci orb publish --host "https://circleci.com" --skip-update-check "./dist/orb.yml" "mathworks/matlab@dev:v2-beta" --token "$CIRCLE_TOKEN"
-    - when:
-            condition:
-              and:
-                - equal: [ true, << pipeline.parameters.publish-v2-beta >> ]
-                - equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
+      - when:
+          condition:
+            and:
+            - equal: [ true, << pipeline.parameters.publish-v2-beta >> ]
+            - equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
+          steps:
+            - run:
+                name: publish v2-beta as dev orb
+                command: |
+                  circleci --help
+                  circleci version
+                  circleci orb publish --host "https://circleci.com" --skip-update-check "./dist/orb.yml" "mathworks/matlab@dev:v2-beta" --token "$CIRCLE_TOKEN"
+            - attach_workspace:
+                at: ./dist/
+      - run:
+          command: |
+            echo "job complete"
 
 workflows:
   lint-pack:
@@ -52,18 +56,19 @@ workflows:
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           filters: *filters
-      - when:
-          condition:
-            and:
-              - equal: [ true, << pipeline.parameters.publish-v2-beta >> ]
-              - equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
-          jobs:
-            - publish-v2-beta:
-                requires:
-                  [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
+      - publish-v2-beta:
+          requires:
+            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
           pipeline-number: << pipeline.number >>
           vcs-type: << pipeline.project.type >>
           requires: [orb-tools/publish]
           filters: *filters
+    when:
+      condition:
+        and:
+          - equal: [ true, << pipeline.parameters.publish-v2-beta >> ]
+          - equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
+      jobs:
+        - publish-v2-beta

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,11 +15,9 @@ filters: &filters
 
 jobs:
   publish-v2-beta:
-    executor:
-      name: default
-      resource_class: medium
-      tag: latest
-  steps:
+    machine:
+      image: ubuntu-2004:202010-01
+    steps:
     - run:
         name: publish v2-beta as dev orb
         command: |
@@ -46,7 +44,8 @@ workflows:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           filters: *filters          
       - publish-v2-beta:
-          condition: 
+        when:
+          condition:
             equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
@@ -54,5 +53,3 @@ workflows:
           vcs-type: << pipeline.project.type >>
           requires: [orb-tools/publish]
           filters: *filters
-          condition: 
-            not: << pipeline.parameters.publish-v2-beta >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,8 @@ jobs:
     docker:
       - image: circleci/circleci-cli:latest
     steps:
+    - attach_workspace:
+        at: ./dist/
     - run:
         name: publish v2-beta as dev orb
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,11 @@ jobs:
           circleci --help
           circleci version
           circleci orb publish --host "https://circleci.com" --skip-update-check "./dist/orb.yml" "mathworks/matlab@dev:v2-beta" --token "$CIRCLE_TOKEN"
+    - when:
+            condition:
+              and:
+                - equal: [ true, << pipeline.parameters.publish-v2-beta >> ]
+                - equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
 
 workflows:
   lint-pack:
@@ -46,15 +51,16 @@ workflows:
           vcs-type: << pipeline.project.type >>
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
-          filters: *filters          
-      - publish-v2-beta:
-          requires:
-            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
-          when:
-            condition:
-              and:
-                - equal: [ true, << pipeline.parameters.publish-v2-beta >> ]
-                - equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
+          filters: *filters
+      - when:
+          condition:
+            and:
+              - equal: [ true, << pipeline.parameters.publish-v2-beta >> ]
+              - equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
+          jobs:
+            - publish-v2-beta:
+                requires:
+                  [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
           pipeline-number: << pipeline.number >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,14 +18,23 @@ jobs:
     docker:
       - image: circleci/circleci-cli:latest
     steps:
-      - run:
-          name: publish v2-beta as dev orb
-          command: |
-            circleci --help
-            circleci version
-            circleci orb publish --host "https://circleci.com" --skip-update-check "./dist/orb.yml" "mathworks/matlab@dev:v2-beta" --token "$CIRCLE_TOKEN"
-      - attach_workspace:
-          at: ./dist/
+      - when:
+          condition: << pipeline.parameters.publish-v2-beta >>
+          steps:
+            - run:
+                name: publish v2-beta as dev orb
+                command: |
+                  circleci --help
+                  circleci version
+                  circleci orb publish --host "https://circleci.com" --skip-update-check "./dist/orb.yml" "mathworks/matlab@dev:v2-beta" --token "$CIRCLE_TOKEN"
+            - attach_workspace:
+                at: ./dist/
+      - unless:
+          condition: << pipeline.parameters.publish-v2-beta >>
+          steps:
+          - run:
+              command: |
+                echo "skipping publish v2-beta"
 
 workflows:
   lint-pack:
@@ -47,13 +56,12 @@ workflows:
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           filters: *filters
+      - publish-v2-beta:
+          requires:
+            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
           pipeline-number: << pipeline.number >>
           vcs-type: << pipeline.project.type >>
           requires: [orb-tools/publish]
           filters: *filters
-    when:
-      condition: << pipeline.parameters.publish-v2-beta >>
-      jobs:
-        - publish-v2-beta

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,8 +54,7 @@ workflows:
           requires: [orb-tools/publish]
           filters: *filters
     when:
-      condition:
-        equal: [ true, << pipeline.parameters.publish-v2-beta >> ]
+      condition: << pipeline.parameters.publish-v2-beta >>
       jobs:
         - publish-v2-beta:
             requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,26 @@ orbs:
   orb-tools: circleci/orb-tools@11.1
   shellcheck: circleci/shellcheck@3.1
 
+parameters:
+  publish-v2-beta:
+    type: boolean
+    default: false
+
 filters: &filters
   tags:
     only: /.*/
+
+jobs:
+  publish-v2-beta:
+    executor:
+      name: default
+      resource_class: medium
+      tag: latest
+  steps:
+    - run:
+        name: publish v2-beta as dev orb
+        command: |
+          circleci orb publish --host "https://circleci.com" --skip-update-check "./dist/orb.yml" "mathworks/matlab@dev:v2-beta" --token "$CIRCLE_TOKEN"
 
 workflows:
   lint-pack:
@@ -27,10 +44,15 @@ workflows:
           vcs-type: << pipeline.project.type >>
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
-          filters: *filters
+          filters: *filters          
+      - publish-v2-beta:
+          condition: 
+            equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
           pipeline-number: << pipeline.number >>
           vcs-type: << pipeline.project.type >>
           requires: [orb-tools/publish]
           filters: *filters
+          condition: 
+            not: << pipeline.parameters.publish-v2-beta >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,8 @@ workflows:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           filters: *filters          
       - publish-v2-beta:
-          requires: [orb-tools/publish]
+          requires:
+            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
       #     when:
       #       condition:
       #         and:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,23 +18,14 @@ jobs:
     docker:
       - image: circleci/circleci-cli:latest
     steps:
-      - when:
-          condition:
-            and:
-            - equal: [ true, << pipeline.parameters.publish-v2-beta >> ]
-            - equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
-          steps:
-            - run:
-                name: publish v2-beta as dev orb
-                command: |
-                  circleci --help
-                  circleci version
-                  circleci orb publish --host "https://circleci.com" --skip-update-check "./dist/orb.yml" "mathworks/matlab@dev:v2-beta" --token "$CIRCLE_TOKEN"
-            - attach_workspace:
-                at: ./dist/
       - run:
+          name: publish v2-beta as dev orb
           command: |
-            echo "job complete"
+            circleci --help
+            circleci version
+            circleci orb publish --host "https://circleci.com" --skip-update-check "./dist/orb.yml" "mathworks/matlab@dev:v2-beta" --token "$CIRCLE_TOKEN"
+      - attach_workspace:
+          at: ./dist/
 
 workflows:
   lint-pack:
@@ -56,9 +47,6 @@ workflows:
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           filters: *filters
-      - publish-v2-beta:
-          requires:
-            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
           pipeline-number: << pipeline.number >>
@@ -71,4 +59,6 @@ workflows:
           - equal: [ true, << pipeline.parameters.publish-v2-beta >> ]
           - equal: [ publish-v2-beta, << pipeline.schedule.name >> ]
       jobs:
-        - publish-v2-beta
+        - publish-v2-beta:
+            requires:
+              [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,8 +26,6 @@ jobs:
             - run:
                 name: publish v2-beta as dev orb
                 command: |
-                  circleci --help
-                  circleci version
                   circleci orb publish --host "https://circleci.com" --skip-update-check "./dist/orb.yml" "mathworks/matlab@dev:v2-beta" --token "$CIRCLE_TOKEN"
       - unless:
           condition: << pipeline.parameters.publish-v2-beta >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,4 @@ workflows:
     when:
       condition: << pipeline.parameters.publish-v2-beta >>
       jobs:
-        - publish-v2-beta:
-            requires:
-              [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
+        - publish-v2-beta

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -4,6 +4,11 @@ orbs:
   orb-tools: circleci/orb-tools@11.1
   win: circleci/windows@5.0
 
+parameters:
+  publish-v2-beta:
+    type: boolean
+    default: false
+
 filters: &filters
   tags:
     only: /.*/

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -5,7 +5,7 @@ orbs:
   win: circleci/windows@5.0
 
 parameters:
-  publish-v2-beta:
+  publish-v1-beta:
     type: boolean
     default: false
 


### PR DESCRIPTION
Adding in a job that publishes to mathworks@matlab/dev:v1-beta when triggered by a weekly schedule.

Weekly schedule configured here:
https://app.circleci.com/settings/project/github/mathworks/matlab-circleci-orb/triggers

I asked on the CircleCI blog on recommendations for prereleases and this was their recommended workflow (see: https://discuss.circleci.com/t/is-there-a-process-for-prereleasing-a-new-major-version-of-an-orb/46934 )



