### PR TITLE
Update supported releases

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
       - checkout
       - matlab/install:
-          release: "R2021bU2"
+          release: "R2020aU2"
           no-output-timeout: 30m
       - run:
           name: Verify the matlab and mex scripts are available

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
       - checkout
       - matlab/install:
-          release: "R2020aU2"
+          release: "R2021bU2"
           no-output-timeout: 30m
       - run:
           name: Verify the matlab and mex scripts are available

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -33,7 +33,12 @@ parsedrelease=$(echo "$PARAM_RELEASE" | tr '[:upper:]' '[:lower:]')
 if [[ $parsedrelease = "latest" ]]; then
     mpmrelease=$(curl https://ssd.mathworks.com/supportfiles/ci/matlab-release/v0/latest)
 else
-    mpmrelease="${PARAM_RELEASE}"
+    mpmrelease="${parsedrelease}"
+fi
+
+# validate release is supported
+if [[ mpmrelease < "r2020b" ]]; then
+    error "Release '${releaseInfo.name}' is not supported. Use 'R2020b' or a later release."
 fi
 
 # install system dependencies

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -37,7 +37,7 @@ else
 fi
 
 # validate release is supported
-if [[ mpmrelease < "r2020b" ]]; then
+if [[ $mpmrelease < "r2020b" ]]; then
     error "Release '${releaseInfo.name}' is not supported. Use 'R2020b' or a later release."
 fi
 

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -38,7 +38,8 @@ fi
 
 # validate release is supported
 if [[ $mpmrelease < "r2020b" ]]; then
-    error "Release '${mpmrelease}' is not supported. Use 'R2020b' or a later release."
+    echo "Release '${mpmrelease}' is not supported. Use 'R2020b' or a later release.">&2
+    exit 1
 fi
 
 # install system dependencies

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -38,7 +38,7 @@ fi
 
 # validate release is supported
 if [[ $mpmrelease < "r2020b" ]]; then
-    error "Release '${releaseInfo.name}' is not supported. Use 'R2020b' or a later release."
+    error "Release '${mpmrelease}' is not supported. Use 'R2020b' or a later release."
 fi
 
 # install system dependencies


### PR DESCRIPTION
Same concept as GitHub Actions... compare parsed release strings with lexicographic ordering, and error if below R2020b