### PR TITLE
Sdfix

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
       - checkout
       - matlab/install:
-          release: "R2021bU2"
+          release: "R2021b"
       - matlab/run-command:
           command: assert(strcmp(version('-release'),'2021b'))
 

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -23,7 +23,7 @@ executors:
       image: ubuntu-2204:2022.07.1
   macos:
     macos:
-      xcode: 13.4.1
+      xcode: 15.1.0
   windows:
     win/default
 
@@ -35,12 +35,12 @@ jobs:
     executor: <<parameters.executor>>
     steps:
       - checkout
-      - matlab/install
+      - matlab/install:
+          no-output-timeout: 30m
       - run:
           name: Verify the matlab and mex scripts are available
           command: |
             set -e
-            matlab -batch version
             os=$(uname)
             if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
               mex.bat -h
@@ -48,6 +48,8 @@ jobs:
               mex -h
             fi
           shell: bash
+      - matlab/run-command:
+          command: version
 
   integration-test-install-release:
     parameters:
@@ -57,13 +59,10 @@ jobs:
     steps:
       - checkout
       - matlab/install:
-          release: R2021a
-      - run:
-          name: Verify the matlab and mex scripts are available
-          command: |
-            set -e
-            matlab -batch "assert(strcmp(version('-release'),'2021a'))"
-          shell: bash
+          release: "R2021bU2"
+          no-output-timeout: 30m
+      - matlab/run-command:
+          command: assert(strcmp(version('-release'),'2021b'))
 
   integration-test-run-command:
     parameters:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -35,8 +35,7 @@ jobs:
     executor: <<parameters.executor>>
     steps:
       - checkout
-      - matlab/install:
-          no-output-timeout: 30m
+      - matlab/install
       - run:
           name: Verify the matlab and mex scripts are available
           command: |
@@ -60,7 +59,6 @@ jobs:
       - checkout
       - matlab/install:
           release: "R2021bU2"
-          no-output-timeout: 30m
       - matlab/run-command:
           command: assert(strcmp(version('-release'),'2021b'))
 

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -107,6 +107,14 @@ jobs:
           startup-options: -logfile mylog.log
       - matlab/run-command:
           command: assert(isfile("mylog.log"), 'logfile was not created as expected')
+      - run:
+          command: |
+            mkdir subdir
+            echo 'onetyone = 11' > subdir/startup.m
+          shell: bash
+      - matlab/run-command:
+          command: assert(onetyone==11, 'onetyone was not set as expected by subdir/startup.m')
+          startup-options: -sd subdir
 
   integration-test-run-tests:
     parameters:

--- a/src/scripts/run-build.sh
+++ b/src/scripts/run-build.sh
@@ -15,11 +15,9 @@ downloadAndRun https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v1/i
 
 # form OS appropriate paths for MATLAB
 os=$(uname)
-workdir=$(pwd)
 scriptdir=$tmpdir
 binext=""
 if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
-    workdir=$(cygpath -w "$workdir")
     scriptdir=$(cygpath -w "$scriptdir")
     binext=".exe"
 fi
@@ -30,10 +28,10 @@ buildCommand="buildtool ${PARAM_TASKS}"
 # create script to execute
 script=command_${RANDOM}
 scriptpath=${tmpdir}/${script}.m
-echo "cd('${workdir//\'/\'\'}');" > "$scriptpath"
+echo "cd(getenv('MW_ORIG_WORKING_FOLDER'));" > "$scriptpath"
 cat << EOF >> "$scriptpath"
 $buildCommand
 EOF
 
 # run MATLAB command
-"${tmpdir}/bin/run-matlab-command$binext" "cd('${scriptdir//\'/\'\'}');$script" $PARAM_ARGS
+"${tmpdir}/bin/run-matlab-command$binext" "setenv('MW_ORIG_WORKING_FOLDER', cd('${scriptdir//\'/\'\'}'));$script" $PARAM_ARGS

--- a/src/scripts/run-command.sh
+++ b/src/scripts/run-command.sh
@@ -15,11 +15,9 @@ downloadAndRun https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v1/i
 
 # form OS appropriate paths for MATLAB
 os=$(uname)
-workdir=$(pwd)
 scriptdir=$tmpdir
 binext=""
 if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
-    workdir=$(cygpath -w "$workdir")
     scriptdir=$(cygpath -w "$scriptdir")
     binext=".exe"
 fi
@@ -27,10 +25,10 @@ fi
 # create script to execute
 script=command_${RANDOM}
 scriptpath=${tmpdir}/${script}.m
-echo "cd('${workdir//\'/\'\'}');" > "$scriptpath"
+echo "cd(getenv('MW_ORIG_WORKING_FOLDER'));" > "$scriptpath"
 cat << EOF >> "$scriptpath"
 ${PARAM_COMMAND}
 EOF
 
 # run MATLAB command
-"${tmpdir}/bin/run-matlab-command$binext" "cd('${scriptdir//\'/\'\'}');$script" $PARAM_ARGS
+"${tmpdir}/bin/run-matlab-command$binext" "setenv('MW_ORIG_WORKING_FOLDER', cd('${scriptdir//\'/\'\'}'));$script" $PARAM_ARGS


### PR DESCRIPTION
Fix the `-sd` option for run-command and run-build. Run-tests never calls `cd`, it just adds the directory containing the scriptgen to the path and then runs it.