### PR TITLE
Fix mpm for mac & windows

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -28,7 +28,7 @@ executors:
       image: ubuntu-2204:2022.07.1
   macos:
     macos:
-      xcode: 13.4.1
+      xcode: 14.3.1
   windows:
     win/default
 

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -29,6 +29,7 @@ executors:
   macos:
     macos:
       xcode: 15.1.0
+    resource_class: macos.x86.medium.gen2
   windows:
     win/default
 

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -28,7 +28,7 @@ executors:
       image: ubuntu-2204:2022.07.1
   macos:
     macos:
-      xcode: 14.3.1
+      xcode: 15.1.0
   windows:
     win/default
 

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -66,16 +66,6 @@ jobs:
       - matlab/install:
           release: "R2021bU2"
           no-output-timeout: 30m
-      - run:
-          name: Verify the matlab and mex scripts are available
-          command: |
-            set -e
-            if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
-              mex.bat -h
-            else
-              mex -h
-            fi
-          shell: bash
       - matlab/run-command:
           command: assert(strcmp(version('-release'),'2021b'))
 

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -46,7 +46,6 @@ jobs:
           name: Verify the matlab and mex scripts are available
           command: |
             set -e
-            matlab-batch version
             os=$(uname)
             if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
               mex.bat -h
@@ -54,6 +53,8 @@ jobs:
               mex -h
             fi
           shell: bash
+      - matlab/run-command:
+          command: version
 
   integration-test-install-release:
     parameters:
@@ -69,8 +70,14 @@ jobs:
           name: Verify the matlab and mex scripts are available
           command: |
             set -e
-            matlab-batch "assert(strcmp(version('-release'),'2021b'))"
+            if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
+              mex.bat -h
+            else
+              mex -h
+            fi
           shell: bash
+      - matlab/run-command:
+          command: assert(strcmp(version('-release'),'2021b'))
 
   integration-test-run-command:
     parameters:
@@ -386,15 +393,11 @@ workflows:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
       - integration-test-install:
-          context:
-            - batch-token
           matrix:
             parameters:
               executor: [linux, windows, macos]
 
       - integration-test-install-release:
-          context:
-            - batch-token
           matrix:
             parameters:
               executor: [linux, windows, macos]

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -76,9 +76,6 @@ curl -o "$mpmpath" -sfL "$mpmbaseurl/$mwarch/mpm"
 chmod +x "$mpmpath"
 mkdir -p "$rootdir"
 
-# check install
-"$mpmpath" --version
-
 # install matlab
 "$mpmpath" install \
     --release=$mpmrelease \

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -27,6 +27,7 @@ os=$(uname)
 tmpdir=$(dirname "$(mktemp -u)")
 rootdir="$tmpdir/matlab_root"
 mpmbaseurl="https://www.mathworks.com/mpm"
+binext=""
 
 # resolve release
 parsedrelease=$(echo "$PARAM_RELEASE" | tr '[:upper:]' '[:lower:]')
@@ -57,28 +58,22 @@ fi
 # set os specific options
 if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
     batchinstalldir='/c/Program Files/matlab-batch'
-    mpmpath="$tmpdir/bin/win64/mpm"
-    mpmsetup="unzip -q $tmpdir/mpm -d $tmpdir"
     mwarch="win64"
-
+    binext=".exe"
     rootdir=$(cygpath "$rootdir")
     mpmpath=$(cygpath "$mpmpath")
 elif [[ $os = Darwin ]]; then
     rootdir="$rootdir/MATLAB.app"
     batchinstalldir='/opt/matlab-batch'
-    mpmpath="$tmpdir/bin/maci64/mpm"
-    mpmsetup="unzip -q $tmpdir/mpm -d $tmpdir"
     mwarch="maci64"
 else
     batchinstalldir='/opt/matlab-batch'
-    mpmpath="$tmpdir/mpm"
-    mpmsetup=""
     mwarch="glnxa64"
 fi
 
 # install mpm
-curl -o "$tmpdir/mpm" -sfL "$mpmbaseurl/$mwarch/mpm"
-eval $mpmsetup
+mpmpath="$tmpdir/mpm$binext"
+curl -o "$mpmpath" -sfL "$mpmbaseurl/$mwarch/mpm"
 chmod +x "$mpmpath"
 mkdir -p "$rootdir"
 

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -71,9 +71,12 @@ else
 fi
 
 # install mpm
-wget -O "$mpmpath" "$mpmbaseurl/$mwarch/mpm"
+curl -o "$mpmpath" -sfL "$mpmbaseurl/$mwarch/mpm"
 chmod +x "$mpmpath"
 mkdir -p "$rootdir"
+
+# check install
+"$mpmpath" --version
 
 # install matlab
 "$mpmpath" install \

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -27,6 +27,7 @@ os=$(uname)
 tmpdir=$(dirname "$(mktemp -u)")
 rootdir="$tmpdir/matlab_root"
 mpmbaseurl="https://www.mathworks.com/mpm"
+mpmpath="$tmpdir/mpm$binext"
 binext=""
 
 # resolve release
@@ -72,7 +73,6 @@ else
 fi
 
 # install mpm
-mpmpath="$tmpdir/mpm$binext"
 curl -o "$mpmpath" -sfL "$mpmbaseurl/$mwarch/mpm"
 chmod +x "$mpmpath"
 mkdir -p "$rootdir"

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -27,8 +27,7 @@ os=$(uname)
 tmpdir=$(dirname "$(mktemp -u)")
 rootdir="$tmpdir/matlab_root"
 mpmbaseurl="https://www.mathworks.com/mpm"
-mpmpath="$tmpdir/mpm$binext"
-binext=""
+mpmpath="$tmpdir/mpm"
 
 # resolve release
 parsedrelease=$(echo "$PARAM_RELEASE" | tr '[:upper:]' '[:lower:]')
@@ -60,9 +59,8 @@ fi
 if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
     batchinstalldir='/c/Program Files/matlab-batch'
     mwarch="win64"
-    binext=".exe"
     rootdir=$(cygpath "$rootdir")
-    mpmpath=$(cygpath "$mpmpath")
+    mpmpath=$(cygpath "$mpmpath.exe")
 elif [[ $os = Darwin ]]; then
     rootdir="$rootdir/MATLAB.app"
     batchinstalldir='/opt/matlab-batch'

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -71,12 +71,9 @@ else
 fi
 
 # install mpm
-echo "DEBUG1"
-curl -o "$mpmpath" -sfL "$mpmbaseurl/$mwarch/mpm"
-echo "DEBUG2"
+wget -O "$mpmpath" "$mpmbaseurl/$mwarch/mpm"
 chmod +x "$mpmpath"
 mkdir -p "$rootdir"
-echo "DEBUG3"
 
 # install matlab
 "$mpmpath" install \

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -71,9 +71,12 @@ else
 fi
 
 # install mpm
+echo "DEBUG1"
 curl -o "$mpmpath" -sfL "$mpmbaseurl/$mwarch/mpm"
+echo "DEBUG2"
 chmod +x "$mpmpath"
 mkdir -p "$rootdir"
+echo "DEBUG3"
 
 # install matlab
 "$mpmpath" install \

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -62,6 +62,7 @@ if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
     rootdir=$(cygpath "$rootdir")
     mpmpath=$(cygpath "$mpmpath.exe")
 elif [[ $os = Darwin ]]; then
+    sudoIfAvailable -c "launchctl limit maxfiles 65536 unlimited" # g3185941
     rootdir="$rootdir/MATLAB.app"
     batchinstalldir='/opt/matlab-batch'
     mwarch="maci64"


### PR DESCRIPTION
* No longer requires extracting after downloading mpm.
* sudo launchctl limit maxfiles 128000 524288 for mac until fix comes