### PR TITLE
Set numeric file descriptor hard limit

### DIFF
--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -68,7 +68,7 @@ if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
 elif [[ $os = Darwin ]]; then
     mwarch="maci64"
     rootdir="$rootdir/MATLAB.app"
-    sudoIfAvailable -c "launchctl limit maxfiles 65536 unlimited" # g3185941
+    sudoIfAvailable -c "launchctl limit maxfiles 65536 200000" # g3185941
 else
     mwarch="glnxa64"
 fi


### PR DESCRIPTION
The macOS runner no longer appears to like the "unlimited" file descriptor hard limit. Setting it to a large number instead.

Fixes #61 