### PR TITLE
v1 doc

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,6 +1,6 @@
 description: >
   Install a specified version of MATLAB. If you use this step to install transformation products, such
-  as MATLAB Coder™ and MATLAB Compiler™, the action does not automatically license such products for you.
+  as MATLAB Coder™ and MATLAB Compiler™, the orb does not automatically license such products for you.
 
 parameters:
   products:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,6 +1,6 @@
 description: >
   Install a specified version of MATLAB. If you use this command to install transformation products, such
-  as MATLAB Coder™ and MATLAB Compiler™, the command does not automatically license such products for you.
+  as MATLAB Coder and MATLAB Compiler, the command does not automatically license such products for you.
 
 parameters:
   products:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,26 +1,26 @@
 description: >
-  Install a specific version of MATLAB. If you use this command to install transformation products, such
-  as MATLAB Coder and MATLAB Compiler, the command does not automatically license such products for you.
+  Install a specific version of MATLAB. (If you use this command to install transformation products,
+  such as MATLAB Coder and MATLAB Compiler, the command does not automatically license such products for you.)
 
 parameters:
   products:
     description: >
       Products to install in addition to MATLAB, specified as a list of product names separated by
       spaces. You can specify this parameter to install most MathWorks products and support packages. The
-      command uses MATLAB Package Manager (`mpm`) for installing products. For a list of supported
+      command uses MATLAB Package Manager (`mpm`) to install products. For a list of supported
       products and their correctly formatted names, see
       https://github.com/mathworks-ref-arch/matlab-dockerfile/blob/main/MPM.md#product-installation-options.
     type: string
     default: ''
   release:
     description: >
-      MATLAB release to install. You can specify R2021a or a later release. By default, the command
-      installs the latest release of MATLAB.
+      MATLAB release to install. You can specify R2021a or a later release. By default, the value of `release`
+      is `latest`. If you do not specify `release`, the command installs the latest release of MATLAB.
     type: string
     default: 'latest'
   no-output-timeout:
     description: >
-      Elapsed time the install command can run without output. The string is a decimal with unit suffix,
+      Elapsed time the command can run without output. The string is a decimal with unit suffix,
       such as “20m”, “1.25h”, “5s”. The default is 10 minutes and the maximum is governed by the
       maximum time a job is allowed to run.
     type: string

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -5,9 +5,13 @@ description: >
 parameters:
   products:
     description: >
-      List of MathWorks products to install.
+      Products to install in addition to MATLAB, specified as a list of product names separated by
+      spaces. You can specify products to set up most MathWorks products and support packages. The 
+      action uses MATLAB Package Manager (mpm) for installing products. For a list of supported 
+      products and their correctly formatted names, see 
+      https://github.com/mathworks-ref-arch/matlab-dockerfile/blob/main/MPM.md#product-installation-options.
     type: string
-    default: 'MATLAB'
+    default: ''
   release:
     description: >
       MATLAB release to install. You can specify R2020a or a later release. By default, the command

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,12 +1,12 @@
 description: >
-  Install a specified version of MATLAB. If you use this command to install transformation products, such
+  Install a specific version of MATLAB. If you use this command to install transformation products, such
   as MATLAB Coder and MATLAB Compiler, the command does not automatically license such products for you.
 
 parameters:
   products:
     description: >
       Products to install in addition to MATLAB, specified as a list of product names separated by
-      spaces. You can specify products to install most MathWorks products and support packages. The
+      spaces. You can specify this parameter to install most MathWorks products and support packages. The
       command uses MATLAB Package Manager (`mpm`) for installing products. For a list of supported
       products and their correctly formatted names, see
       https://github.com/mathworks-ref-arch/matlab-dockerfile/blob/main/MPM.md#product-installation-options.

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,20 +1,20 @@
 description: >
-  Install MATLAB on a Linux machine executor. Currently, this command is available only for public
-  projects and does not include transformation products, such as MATLAB Coder and MATLAB Compiler.
+  Install a specified version of MATLAB. If you use this orb to install transformation products, such
+  as MATLAB Coder™ and MATLAB Compiler™, the action does not automatically license such products for you.
 
 parameters:
   products:
     description: >
       Products to install in addition to MATLAB, specified as a list of product names separated by
       spaces. You can specify products to set up most MathWorks products and support packages. The
-      action uses MATLAB Package Manager (mpm) for installing products. For a list of supported
+      orb uses MATLAB Package Manager (mpm) for installing products. For a list of supported
       products and their correctly formatted names, see
       https://github.com/mathworks-ref-arch/matlab-dockerfile/blob/main/MPM.md#product-installation-options.
     type: string
     default: ''
   release:
     description: >
-      MATLAB release to install. You can specify R2020a or a later release. By default, the command
+      MATLAB release to install. You can specify R2021a or a later release. By default, the command
       installs the latest release of MATLAB.
     type: string
     default: 'latest'

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -6,9 +6,9 @@ parameters:
   products:
     description: >
       Products to install in addition to MATLAB, specified as a list of product names separated by
-      spaces. You can specify products to set up most MathWorks products and support packages. The 
-      action uses MATLAB Package Manager (mpm) for installing products. For a list of supported 
-      products and their correctly formatted names, see 
+      spaces. You can specify products to set up most MathWorks products and support packages. The
+      action uses MATLAB Package Manager (mpm) for installing products. For a list of supported
+      products and their correctly formatted names, see
       https://github.com/mathworks-ref-arch/matlab-dockerfile/blob/main/MPM.md#product-installation-options.
     type: string
     default: ''

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,5 +1,5 @@
 description: >
-  Install a specified version of MATLAB. If you use this orb to install transformation products, such
+  Install a specified version of MATLAB. If you use this step to install transformation products, such
   as MATLAB Coder™ and MATLAB Compiler™, the action does not automatically license such products for you.
 
 parameters:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -20,7 +20,7 @@ parameters:
     default: 'latest'
   no-output-timeout:
     description: >
-      Elapsed time the tests can run without output. The string is a decimal with unit suffix,
+      Elapsed time the install can run without output. The string is a decimal with unit suffix,
       such as “20m”, “1.25h”, “5s”. The default is 10 minutes and the maximum is governed by the
       maximum time a job is allowed to run.
     type: string

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,13 +1,13 @@
 description: >
-  Install a specified version of MATLAB. If you use this step to install transformation products, such
-  as MATLAB Coder™ and MATLAB Compiler™, the orb does not automatically license such products for you.
+  Install a specified version of MATLAB. If you use this command to install transformation products, such
+  as MATLAB Coder™ and MATLAB Compiler™, the command does not automatically license such products for you.
 
 parameters:
   products:
     description: >
       Products to install in addition to MATLAB, specified as a list of product names separated by
-      spaces. You can specify products to set up most MathWorks products and support packages. The
-      orb uses MATLAB Package Manager (mpm) for installing products. For a list of supported
+      spaces. You can specify products to install most MathWorks products and support packages. The
+      command uses MATLAB Package Manager (`mpm`) for installing products. For a list of supported
       products and their correctly formatted names, see
       https://github.com/mathworks-ref-arch/matlab-dockerfile/blob/main/MPM.md#product-installation-options.
     type: string
@@ -20,7 +20,7 @@ parameters:
     default: 'latest'
   no-output-timeout:
     description: >
-      Elapsed time the install can run without output. The string is a decimal with unit suffix,
+      Elapsed time the install command can run without output. The string is a decimal with unit suffix,
       such as “20m”, “1.25h”, “5s”. The default is 10 minutes and the maximum is governed by the
       maximum time a job is allowed to run.
     type: string

--- a/src/examples/run-build.yml
+++ b/src/examples/run-build.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    matlab: mathworks/matlab@0
+    matlab: mathworks/matlab@1
   jobs:
     build:
       machine:

--- a/src/examples/run-custom-script.yml
+++ b/src/examples/run-custom-script.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    matlab: mathworks/matlab@0
+    matlab: mathworks/matlab@1
   jobs:
     build:
       machine:

--- a/src/examples/run-tests-with-report.yml
+++ b/src/examples/run-tests-with-report.yml
@@ -4,7 +4,7 @@ description: >
 usage:
   version: 2.1
   orbs:
-    matlab: mathworks/matlab@0
+    matlab: mathworks/matlab@1
   jobs:
     build:
       machine:

--- a/src/examples/run-tests-with-report.yml
+++ b/src/examples/run-tests-with-report.yml
@@ -11,7 +11,9 @@ usage:
         image: ubuntu-2204:2022.07.1
       steps:
         - checkout
-        - matlab/install
+        # Install Simulink and Simulink Test in addition to MATLAB
+        - matlab/install:
+            products: Simulink Simulink_Test
         - matlab/run-tests:
             test-results-junit: test-results/matlab/results.xml
         - store_test_results:


### PR DESCRIPTION
Also check out ` no-output-timeout` in `src/commands/install.yml`. I added this because sometimes if you need a lot of products it will take longer than 10 minutes. I took the text we had already written for this parameter from run-tests and changed "test" language to "install"

Addresses:
https://github.com/mathworks/matlab-circleci-orb/issues/55
https://github.com/mathworks/matlab-circleci-orb/issues/56
https://github.com/mathworks/matlab-circleci-orb/issues/59