### PR TITLE
Install Intel version of MATLAB on Apple silicon prior to R2023b

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -60,6 +60,8 @@ jobs:
     parameters:
       executor:
         type: executor
+      release:
+        type: string
     executor: <<parameters.executor>>
     steps:
       - checkout

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -470,7 +470,7 @@ workflows:
               executor: [linux, windows, macos, macos-arm]
               release: [R2023bU1]
 
-      - integration-test-install-intel-on-arm-release:
+      - integration-test-install-release:
           executor: macos-arm
           release: R2023aU1
 

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -64,10 +64,10 @@ jobs:
     steps:
       - checkout
       - matlab/install:
-          release: "R2023bU1"
+          release: <<parameters.release>>
           no-output-timeout: 30m
       - matlab/run-command:
-          command: "assert(strcmp(version('-release'),'2023b') && strcmp(version('-description'),'Update 1'))"
+          command: "exp='<<parameters.release>>'; assert(strcmp(version('-release'),exp(2:6)))"
 
   integration-test-run-command:
     parameters:
@@ -466,6 +466,11 @@ workflows:
           matrix:
             parameters:
               executor: [linux, windows, macos, macos-arm]
+              release: R2023bU1
+
+      - integration-test-install-intel-on-arm-release:
+          executor: macos-arm
+          release: R2023aU1
 
       - integration-test-run-command:
           matrix:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -13,7 +13,7 @@ integration-tests: &integration-tests
     orb-tools/pack,
     integration-test-install,
     integration-test-install-release,
-    integration-test-install-release-intel-on-arm,
+    integration-test-install-release-macos-intel-on-arm,
     integration-test-run-command,
     integration-test-run-tests
   ]
@@ -472,7 +472,7 @@ workflows:
               release: [R2023bU1]
 
       - integration-test-install-release:
-          name: integration-test-install-release-intel-on-arm
+          name: integration-test-install-release-macos-intel-on-arm
           executor: macos-arm
           release: R2023aU1
 

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -13,6 +13,7 @@ integration-tests: &integration-tests
     orb-tools/pack,
     integration-test-install,
     integration-test-install-release,
+    integration-test-install-release-intel-on-arm,
     integration-test-run-command,
     integration-test-run-tests
   ]
@@ -471,6 +472,7 @@ workflows:
               release: [R2023bU1]
 
       - integration-test-install-release:
+          name: integration-test-install-release-intel-on-arm
           executor: macos-arm
           release: R2023aU1
 

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -468,7 +468,7 @@ workflows:
           matrix:
             parameters:
               executor: [linux, windows, macos, macos-arm]
-              release: R2023bU1
+              release: [R2023bU1]
 
       - integration-test-install-intel-on-arm-release:
           executor: macos-arm

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -77,7 +77,7 @@ if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
     mpmdir=$(cygpath "$mpmdir")
     batchdir=$(cygpath "$batchdir")
 elif [[ $os = Darwin ]]; then
-    if [[ $arch = arm64 && $mpmrelease >= "r2023b" ]]; then
+    if [[ $arch = arm64 && ! $mpmrelease < "r2023b" ]]; then
          mwarch="maca64"
      else
          mwarch="maci64"

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -49,6 +49,7 @@ fi
 
 # install Intel version on Apple silicon prior to R2023b
 if [[ $os = Darwin && $arch = arm64 && $mpmrelease < "r2023b" ]]; then
+    sudoIfAvailable -c "softwareupdate --install-rosetta --agree-to-license"
     arch="x86_64"
 fi
 

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -47,6 +47,11 @@ if [[ $mpmrelease < "r2020b" ]]; then
     exit 1
 fi
 
+# install Intel version on Apple silicon prior to R2023b
+if [[ $os = Darwin && $arch = arm64 && $mpmrelease < "r2023b" ]]; then
+    arch="x86_64"
+fi
+
 # install system dependencies
 if [[ $os = Linux ]]; then
     # install MATLAB dependencies
@@ -57,7 +62,7 @@ if [[ $os = Linux ]]; then
         wget \
         unzip \
         ca-certificates"
-elif [[ $os = Darwin && $arch == arm64 ]]; then
+elif [[ $os = Darwin && $arch = arm64 ]]; then
     # install Java runtime
     jdkpkg="$tmpdir/jdk.pkg"
     curl -sfL https://corretto.aws/downloads/latest/amazon-corretto-8-aarch64-macos-jdk.pkg -o $jdkpkg
@@ -72,7 +77,7 @@ if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
     mpmdir=$(cygpath "$mpmdir")
     batchdir=$(cygpath "$batchdir")
 elif [[ $os = Darwin ]]; then
-    if [[ $arch == arm64 ]]; then
+    if [[ $arch = arm64 ]]; then
          mwarch="maca64"
      else
          mwarch="maci64"


### PR DESCRIPTION
This pull request adds functionality to install the Intel version of MATLAB on Apple silicon runners when a release prior to R2023b is specified.

Without this functionality, when a release prior to R2023b is specified on an Apple silicon runner, MATLAB will appear to install but fail during execution.