### PR TITLE
Update Path to include MATLAB Runtime

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -53,12 +53,13 @@ jobs:
           name: Verify MATLAB runtime in PATH
           command: |
             set -e
-            if [[ ":$PATH:" == *"runtime"* ]]; then
+            if [[ "${PATH}" == *"runtime"* ]]; then
               echo "MATLAB Runtime is correctly set in PATH."
             else
               echo "MATLAB Runtime is NOT set in PATH."
               exit 1
             fi
+          shell: bash
       - matlab/run-command:
           command: version
 

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -49,6 +49,16 @@ jobs:
               mex -h
             fi
           shell: bash
+      - run:
+          name: Verify MATLAB runtime in PATH
+          command: |
+            set -e
+            if [[ ":$PATH:" == *"runtime"* ]]; then
+              echo "MATLAB Runtime is correctly set in PATH."
+            else
+              echo "MATLAB Runtime is NOT set in PATH."
+              exit 1
+            fi
       - matlab/run-command:
           command: version
 

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -146,5 +146,5 @@ chmod +x "$batchdir/matlab-batch$binext"
     ${releasestatus} \
     --products ${PARAM_PRODUCTS} MATLAB
 
-# add MATLAB and matlab-batch to path
-echo 'export PATH="'$rootdir'/bin:'$batchdir':$PATH"' >> $BASH_ENV
+# add MATLAB, MATLAB Runtime and matlab-batch to path
+echo 'export PATH="'$rootdir'/bin:'$rootdir'/runtime/'$mwarch':'$batchdir':$PATH"' >> $BASH_ENV


### PR DESCRIPTION
- Adds the runtime directory to system path, according to [mcr-path-settings-for-run-time-deployment](https://www.mathworks.com/help/compiler/mcr-path-settings-for-run-time-deployment.html).
- This enhancement is detailed here - [setup-matlab/issues/129](https://github.com/matlab-actions/setup-matlab/issues/129).