### PR TITLE
Add runtime directory to system PATH for windows

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -49,6 +49,20 @@ jobs:
               mex -h
             fi
           shell: bash
+      - run:
+          name: Verify MATLAB runtime in windows system path
+          command: |
+            set -e
+            os=$(uname)
+            if [[ $os = CYGWIN* || $os = MINGW* || $os = MSYS* ]]; then
+              if [[ "${PATH}" == *"runtime"* ]]; then
+                echo "MATLAB Runtime is correctly set in PATH."
+              else
+                echo "MATLAB Runtime is NOT set in windows PATH."
+                exit 1
+              fi
+            fi
+          shell: bash
       - matlab/run-command:
           command: version
 

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -115,6 +115,8 @@ if [[ "$os" = CYGWIN* || "$os" = MINGW* || "$os" = MSYS* ]]; then
     rootdir=$(cygpath "$rootdir")
     mpmdir=$(cygpath "$mpmdir")
     batchdir=$(cygpath "$batchdir")
+    # add MATLAB Runtime to path for windows
+    echo 'export PATH="'$rootdir'/runtime/'$mwarch':$PATH"' >> $BASH_ENV
 elif [[ "$os" = "Darwin" ]]; then
     if [[ "$arch" = "arm64" && ! "$mpmrelease" < "r2023b" ]]; then
          mwarch="maca64"


### PR DESCRIPTION
This PR adds the runtime directory to system path for windows OS, according to [mcr-path-settings-for-run-time-deployment](https://www.mathworks.com/help/compiler/mcr-path-settings-for-run-time-deployment.html).