### PR TITLE
Update prerelease support, security email, and base images

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -20,11 +20,11 @@ integration-tests: &integration-tests
 executors:
   linux: &linux-executor
     machine:
-      image: ubuntu-2204:2024.01.1
+      image: ubuntu-2604:2026.07.1
   macos:
     macos:
-      xcode: 15.3.0
-    resource_class: macos.m1.medium.gen1
+      xcode: 26.6.0
+    resource_class: m4pro.medium
   windows:
     win/default
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ orbs:
 jobs:
   run-matlab-build:    
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2604:current
     steps:
       - checkout
       - matlab/install
@@ -43,7 +43,7 @@ orbs:
 jobs:
   run-matlab-tests:    
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2604:current
     steps:
       - checkout
       - matlab/install
@@ -79,7 +79,7 @@ orbs:
 jobs:
   run-matlab-and-simulink-tests:    
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2604:current
     steps:
       - checkout
       - matlab/install:
@@ -105,7 +105,7 @@ orbs:
 jobs:
   run-matlab-script:    
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2604:current
     steps:
       - checkout
       - matlab/install:
@@ -135,7 +135,7 @@ orbs:
 jobs:
   run-matlab-tests:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2604:current
     steps:
       - checkout
       - matlab/install
@@ -158,14 +158,15 @@ orbs:
 executors:
   linux:
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2604:current
   windows:
     resource_class: windows.medium
     machine:
       image: windows-server-2022-gui:current
   macos:
     macos:
-      xcode: 14.2.0
+      xcode: 26.6.0
+    resource_class: m4pro.medium
 
 jobs:
   run-matlab-build:
@@ -203,7 +204,7 @@ orbs:
 jobs:
   run-matlab-tests:    
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2604:current
     parallelism: 4
     steps:
       - checkout

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,6 +1,6 @@
-# Reporting Security Vulnerabilities 
+# Reporting Security Vulnerabilities
 
-If you believe you have discovered a security vulnerability, please report it to 
-[security@mathworks.com](mailto:security@mathworks.com). Please see 
-[MathWorks Vulnerability Disclosure Policy for Security Researchers](https://www.mathworks.com/company/aboutus/policies_statements/vulnerability-disclosure-policy.html) 
-for additional information.  
+If you believe you have discovered a security vulnerability, please report it to
+[product-security@mathworks.com](mailto:product-security@mathworks.com). Please see
+[MathWorks Vulnerability Disclosure Policy for Security Researchers](https://www.mathworks.com/company/aboutus/policies_statements/vulnerability-disclosure-policy.html)
+for additional information.

--- a/src/scripts/install.sh
+++ b/src/scripts/install.sh
@@ -51,11 +51,9 @@ mpmbaseurl="https://www.mathworks.com/mpm"
 eval "$UTILS"
 # shellcheck disable=SC1090
 source ~/.matlab-circleci-orb/install-metadata.sh
-# RELEASE and RELEASE_STATUS are defined in install-metadata.sh
+# RELEASE is defined in install-metadata.sh
 # shellcheck disable=SC2153
 mpmrelease=$RELEASE
-# shellcheck disable=SC2153
-releasestatus=$RELEASE_STATUS
 
 # install system dependencies
 if [[ "$os" = "Linux" ]]; then
@@ -119,7 +117,6 @@ else
     "$mpmdir/mpm$binext" install \
         --release="$mpmrelease" \
         --destination="$rootdir" \
-        ${releasestatus} \
         --products ${PARAM_PRODUCTS} MATLAB
 fi
 

--- a/src/scripts/prepare-install-metadata.sh
+++ b/src/scripts/prepare-install-metadata.sh
@@ -4,18 +4,11 @@ mkdir -p ~/.matlab-circleci-orb
 eval "$UTILS"
 
 mpmrelease=""
-releasestatus=""
 parsedrelease=$(echo "$PARAM_RELEASE" | tr '[:upper:]' '[:lower:]')
 if [[ "$parsedrelease" = "latest" ]]; then
     mpmrelease=$(stream https://ssd.mathworks.com/supportfiles/ci/matlab-release/v0/latest)
 elif [[ "$parsedrelease" = "latest-including-prerelease" ]]; then
-    fetched=$(stream https://ssd.mathworks.com/supportfiles/ci/matlab-release/v0/latest-including-prerelease)
-    if [[ "$fetched" == *prerelease ]]; then
-        mpmrelease="${fetched%prerelease}"
-        releasestatus="--release-status=Prerelease"
-    else
-        mpmrelease="$fetched"
-    fi
+    mpmrelease=$(stream https://ssd.mathworks.com/supportfiles/ci/matlab-release/v0/latest-including-prerelease)
 else
     mpmrelease="$parsedrelease"
 fi
@@ -26,6 +19,5 @@ if [[ "$mpmrelease" < "r2020b" ]]; then
 fi
 
 echo "export RELEASE=\"$mpmrelease\"" > ~/.matlab-circleci-orb/install-metadata.sh
-echo "export RELEASE_STATUS=\"$releasestatus\"" >> ~/.matlab-circleci-orb/install-metadata.sh
 SORTED_PRODUCTS=$(echo "$PARAM_PRODUCTS" | tr ' ' '\n' | sort | xargs)
 echo "export PRODUCTS=\"$SORTED_PRODUCTS\"" >> ~/.matlab-circleci-orb/install-metadata.sh


### PR DESCRIPTION
I originally updated the SECURITY.md. Then I found that the current pipelines don't work because CircleCI changed their macOS support range and we also needed to update the `latest-including-prerelease` logic here.